### PR TITLE
Add SQLite user tracking and admin commands

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,0 +1,52 @@
+import os
+import sqlite3
+
+DB_PATH = "users.db"
+
+def init_db() -> None:
+    conn = None
+    try:
+        db_exists = os.path.isfile(DB_PATH)
+        conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+        cursor = conn.cursor()
+        if not db_exists:
+            cursor.execute(
+                """
+                CREATE TABLE users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    telegram_id INTEGER UNIQUE,
+                    username TEXT,
+                    first_name TEXT,
+                    date_joined TEXT
+                )
+                """
+            )
+        else:
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='users'"
+            )
+            if not cursor.fetchone():
+                cursor.execute(
+                    """
+                    CREATE TABLE users (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        telegram_id INTEGER UNIQUE,
+                        username TEXT,
+                        first_name TEXT,
+                        date_joined TEXT
+                    )
+                    """
+                )
+        conn.commit()
+    except sqlite3.Error:
+        pass
+    finally:
+        if conn:
+            conn.close()
+
+
+def get_connection() -> sqlite3.Connection:
+    return sqlite3.connect(DB_PATH, check_same_thread=False)
+
+
+init_db()

--- a/env.py
+++ b/env.py
@@ -7,3 +7,4 @@ TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.proxyapi.ru/openai/v1")
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
+ADMIN_USERNAME = "my_admin_login"

--- a/handlers.py
+++ b/handlers.py
@@ -1,16 +1,30 @@
 import telebot
 
 from gpt_client import GptClient
+from models import add_user_if_not_exists, get_all_users
+from env import ADMIN_USERNAME
 
 
 def register_handlers(bot: telebot.TeleBot) -> None:
     @bot.message_handler(commands=["start"])
-    def cmd_start(msg: telebot.types.Message) -> None:
-        bot.send_message(msg.chat.id, "Привет! Я готов служить.")
+    def cmd_start(message: telebot.types.Message) -> None:
+        add_user_if_not_exists(message)
+        first_name = message.from_user.first_name
+        bot.send_message(message.chat.id, f"Добро пожаловать, {first_name}")
+
+    @bot.message_handler(commands=["all_users"])
+    def cmd_all_users(message: telebot.types.Message) -> None:
+        if message.from_user.username != ADMIN_USERNAME:
+            return
+        users = get_all_users()
+        lines = ["Пользователи:"]
+        for username, date_joined in users:
+            lines.append(f"- @{username} — {date_joined}")
+        bot.send_message(message.chat.id, "\n".join(lines))
 
     @bot.message_handler(content_types=["text"])
-    def text_handler(msg: telebot.types.Message) -> None:
-        if msg.text.startswith("/"):
+    def text_handler(message: telebot.types.Message) -> None:
+        if message.text.startswith("/"):
             return
-        answer = GptClient().ask_gpt(msg.text)
-        bot.send_message(msg.chat.id, answer)
+        answer = GptClient().ask_gpt(message.text)
+        bot.send_message(message.chat.id, answer)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+import sqlite3
+import telebot
+
+from database import get_connection
+
+
+def add_user_if_not_exists(message: telebot.types.Message) -> None:
+    conn = get_connection()
+    try:
+        cursor = conn.cursor()
+        telegram_id = message.from_user.id
+        username = message.from_user.username
+        first_name = message.from_user.first_name
+        cursor.execute(
+            "SELECT id FROM users WHERE telegram_id = ?",
+            (telegram_id,),
+        )
+        if cursor.fetchone() is None:
+            date_joined = datetime.now().date().isoformat()
+            cursor.execute(
+                """
+                INSERT INTO users (telegram_id, username, first_name, date_joined)
+                VALUES (?, ?, ?, ?)
+                """,
+                (telegram_id, username, first_name, date_joined),
+            )
+            conn.commit()
+    except sqlite3.Error:
+        pass
+    finally:
+        conn.close()
+
+
+def get_all_users() -> list[tuple]:
+    conn = get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT username, date_joined FROM users ORDER BY id"
+        )
+        return cursor.fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- initialize SQLite database for Telegram users
- store new users when they start the bot
- allow admin to list all users
- configure admin username in `env.py`

## Testing
- `python -m py_compile env.py database.py models.py handlers.py bot.py gpt_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685451b88bb48329a2404c6e860d68f2