### PR TITLE
Implement receipt support for YooKassa payments

### DIFF
--- a/BOT_DOC.md
+++ b/BOT_DOC.md
@@ -130,7 +130,7 @@
 
 ### `yookassa_payment.py`
 - Функции работы с YooKassa:
-  - `create_payment(user_id, amount, credits=None)` — создаёт платёж и возвращает объект `Payment`;
+  - `create_payment(user_id, amount, user_email, credits=None)` — создаёт платёж и возвращает объект `Payment`;
   - `payment_status(payment_id)` — проверяет текущий статус платежа;
   - `add_pending(payment_id, user_id, amount, credits)` — регистрирует неоплаченную транзакцию;
   - `list_pending()` и `remove_pending(payment_id)` — управляют списком ожидания;

--- a/bots/DS/handlers.py
+++ b/bots/DS/handlers.py
@@ -171,7 +171,7 @@ def register_handlers(bot: telebot.TeleBot) -> None:
             try:
                 from shared.yookassa_payment import create_payment, add_pending
 
-                payment = create_payment(answer.from_user.id, float(amnt))
+                payment = create_payment(answer.from_user.id, float(amnt), answer.text)
                 add_pending(payment.id, answer.from_user.id, float(amnt), float(creds))
             except Exception as exc:
                 logging.exception("Payment error: %s", exc)


### PR DESCRIPTION
## Summary
- extend `create_payment` to include email receipts and idempotence key
- pass user email from the bot handlers
- document updated `create_payment` signature

## Testing
- `python -m py_compile shared/yookassa_payment.py bots/DS/handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_686d3a7fe8308329be27e5896430f0a8